### PR TITLE
Fix continue-on-error placement in Safety CLI workflow step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       with:
         api-key: ${{ secrets.SAFETY_API_KEY }}
         scan: true
-        continue-on-error: true
+      continue-on-error: true
 
     - name: Upload security reports
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Move `continue-on-error` from inside the `with` block to the step level in the Safety CLI workflow step.

## Problem

`continue-on-error` was incorrectly placed inside the `with:` block as a parameter to the action:

```yaml
- name: Run Safety CLI
  uses: pyupio/safety-action@v1
  with:
    api-key: ${{ secrets.SAFETY_API_KEY }}
    scan: true
    continue-on-error: true  # ❌ Wrong - this is an action input, not a step property
```

## Fix

Move `continue-on-error` to the step level where it belongs:

```yaml
- name: Run Safety CLI
  uses: pyupio/safety-action@v1
  with:
    api-key: ${{ secrets.SAFETY_API_KEY }}
    scan: true
  continue-on-error: true  # ✅ Correct - this is a step property
```

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._